### PR TITLE
fix:utterances

### DIFF
--- a/hivemind_listener/__init__.py
+++ b/hivemind_listener/__init__.py
@@ -72,7 +72,7 @@ class HMCallbacks(ListenerCallbacks):
     def text_callback(cls, utterance: str, lang: str):
         LOG.info(f"STT: {utterance}")
         cls.bus.emit(Message("recognizer_loop:utterance",
-                             {"utterances": utterance, "lang": lang}))
+                             {"utterances": [utterance], "lang": lang}))
 
 
 @dataclass


### PR DESCRIPTION
typo, sending utterances as string instead of list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the structure of the emitted message for speech-to-text results, changing the `utterances` field from a string to a list.

- **Bug Fixes**
	- Adjusted data format to ensure compatibility with listeners expecting a list for the `utterances` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->