### PR TITLE
performance: speed up b64 operations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ hivemind_bus_client>=0.1.0,<1.0.0
 ovos-plugin-manager<1.0.0
 hivemind-core>=0.1.0,<1.0.0
 click
+pybase64


### PR DESCRIPTION
closes https://github.com/JarbasHiveMind/hivemind-listener/issues/16

some quick test logs in my laptop:

base64
```
# DEBUG - b64 encoding took: 4.727600025944412e-05 seconds
# DEBUG - b64 encoding took: 6.373100040946156e-05 seconds

# DEBUG - b64 decoding took: 0.00011195099796168506 seconds   
```

pybase64
```
# DEBUG - b64 encoding took: 1.8701997760217637e-05 seconds

# DEBUG - b64 decoding took: 5.4245996579993516e-05 seconds  
# DEBUG - b64 decoding took: 6.30389986326918e-05 seconds
# DEBUG - b64 decoding took: 4.8896996304392815e-05 seconds
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced audio data processing with improved Base64 encoding and decoding.
	- Added logging for performance measurement during encoding and decoding operations.

- **Chores**
	- Updated dependencies in the requirements file to include `click` and `pybase64`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->