### PR TITLE
fix: wakeword key

### DIFF
--- a/hivemind_audio_binary_protocol/protocol.py
+++ b/hivemind_audio_binary_protocol/protocol.py
@@ -212,9 +212,10 @@ class AudioBinaryProtocol(BinaryDataHandlerProtocol):
             tts = OVOSTTSFactory.create(self.config["tts"])
             LOG.debug(f"Loading VAD '{self.config['vad']['module']}': {self.config['vad']}")
             vad = OVOSVADFactory.create(self.config["vad"])
-
+            ww = self.config.get("wakeword") or self.config.get("wake_word") # backwards compat
+          
             self.plugins = PluginOptions(
-                wakeword=self.config["wakeword"],  # TODO - allow per client
+                wakeword=ww,  # TODO - allow per client
                 stt=stt,
                 tts=tts,
                 vad=vad,


### PR DESCRIPTION
code uses "wakeword" but readme and mycroft.conf use "wake_word"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced wake word configuration handling to support multiple key formats for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->